### PR TITLE
Don't set replication when using default writing configuration

### DIFF
--- a/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
+++ b/core/client/hdfs/src/main/java/alluxio/hadoop/AbstractFileSystem.java
@@ -338,8 +338,7 @@ public abstract class AbstractFileSystem extends org.apache.hadoop.fs.FileSystem
       if (!mFileSystem.exists(uri) || mFileSystem.getStatus(uri).isFolder()) {
         return false;
       }
-      mFileSystem.setAttribute(uri, (SetAttributePOptions) SetAttributePOptions.newBuilder()
-          .setReplicationMin(replication).build());
+      LOG.debug("Skipping set replicationMin attribute for {}", path);
       return true;
     } catch (AlluxioException e) {
       throw new IOException(e);


### PR DESCRIPTION
ReplicationMin and replicationMax are supposed to be effective in 'alluxio.user.file.replication.max' and 'alluxio.user.file.replication.min'

### What changes are proposed in this pull request?
Deleted set replicationMin configuration when calling setReplication in client. In case of some temporary files will be pinned in Alluxio. 

### Why are the changes needed?
Sometimes yarn and spark jobs will leave some temporary files but not deleted, which are also pinned in Alluxio. Yarn will call setReplication when job running and default replication parameter is '10'. In other words, some temporary files may have 10 replications in Alluxio, which will waste worker capacity. With time goes on, it will be many pinned temporary files in Alluxio. I think it is useless since there already have 'alluxio.user.file.replication.max' and 'alluxio.user.file.replication.min'. 

### Does this PR introduce any user facing changes?
none
